### PR TITLE
Add selected resources reset

### DIFF
--- a/changelog/unreleased/reset-selection
+++ b/changelog/unreleased/reset-selection
@@ -1,0 +1,6 @@
+Bugfix: Reset resource selection when opening folder
+
+We've added reset of selected resources when a folder is opened.
+This prevents from having selected resources which are not visible.
+
+https://github.com/owncloud/file-picker/pull/11

--- a/src/components/ListResources.vue
+++ b/src/components/ListResources.vue
@@ -76,6 +76,7 @@ export default {
 
   methods: {
     openFolder(path) {
+      this.resetResourceSelection()
       this.$emit('openFolder', path)
     },
 
@@ -130,6 +131,11 @@ export default {
 
     sortResources(resources) {
       return resources.sort(sortByName)
+    },
+
+    resetResourceSelection() {
+      this.selectedResources = []
+      this.$emit('selectResources', [])
     }
   }
 }


### PR DESCRIPTION
We've added reset of selected resources when a folder is opened. This prevents from having selected resources which are not visible.