### PR TITLE
Set npm access to public

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -339,6 +339,7 @@ def release(ctx):
           'token': {
             'from_secret': 'npm_token',
           },
+          'access': 'public',
         },
         'when': {
           'ref': [


### PR DESCRIPTION
By default, the access is set to private. This should push the package as a public one.