### PR TITLE
Do not import Vue

### DIFF
--- a/changelog/unreleased/do-not-import-vue
+++ b/changelog/unreleased/do-not-import-vue
@@ -1,0 +1,5 @@
+Enhancement: Do not import Vue
+
+We've stopped importing Vue because it is not bundled during the build process and needs to be included as a global variable in the target web application.
+
+https://github.com/owncloud/file-picker/pull/16

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,6 @@
 </template>
 
 <script>
-import Vue from 'vue'
 import sdk from 'owncloud-sdk'
 import DesignSystem from 'owncloud-design-system'
 import initVueAuthenticate from './services/auth'
@@ -26,11 +25,12 @@ import FilePicker from './components/FilePicker.vue'
 import Login from './components/Login.vue'
 
 // Init sdk and design system
+/* global Vue */
 Vue.prototype.$client = new sdk()
 Vue.use(DesignSystem)
 
 export default {
-  name: 'App',
+  name: 'FilePicker',
 
   components: {
     FilePicker,


### PR DESCRIPTION
We've stopped importing Vue because it is not bundled during the build process and needs to be included as a global variable in the target web application.