### PR TITLE
Bootstrap Vue

### DIFF
--- a/changelog/unreleased/bootstrap-vue
+++ b/changelog/unreleased/bootstrap-vue
@@ -1,0 +1,5 @@
+Enhancement: Bootstrap Vue
+
+We've bootstrapped Vue to add access to the file picker via window.
+
+https://github.com/owncloud/file-picker/pull/19

--- a/src/App.vue
+++ b/src/App.vue
@@ -30,7 +30,7 @@ Vue.prototype.$client = new sdk()
 Vue.use(DesignSystem)
 
 export default {
-  name: 'FilePicker',
+  name: 'App',
 
   components: {
     FilePicker,

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,5 @@
-import Vue from 'vue'
+import Vue from './vue'
 import App from './App.vue'
-
-Vue.config.productionTip = false
 
 new Vue({
   render: h => {

--- a/src/vue.js
+++ b/src/vue.js
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+
+Vue.config.productionTip = false
+window.Vue = Vue
+
+export default Vue


### PR DESCRIPTION
Enable access to the Vue instance via window object and rename app component to prevent an endless created loop.