### PR TITLE
Manual setting of redirect_uri in auth service

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -29,13 +29,14 @@ export function initVueAuthenticate(config) {
         Object.assign(openIdConfig, {
           authority: config.auth.url,
           metadataUrl: config.auth.metaDataUrl,
-          client_id: config.auth.clientId
+          client_id: config.auth.clientId,
+          redirect_uri: config.auth.redirectUri ? config.auth.redirectUri : window.location.origin + '/oidc-callback.html'
         })
       } else {
         // oauth2 setup
         Object.assign(openIdConfig, {
           authority: config.auth.url,
-          // with OAuth2 we need to se the metadata manually
+          // with OAuth2 we need to set the metadata manually
           metadata: {
             issuer: config.auth.url,
             authorization_endpoint: config.auth.authUrl,
@@ -43,6 +44,7 @@ export function initVueAuthenticate(config) {
             userinfo_endpoint: ''
           },
           client_id: config.auth.clientId,
+          redirect_uri: config.auth.redirectUri ? config.auth.redirectUri : window.location.origin + '/oidc-callback.html',
           response_type: 'token', // token is implicit flow - to be killed
           scope: 'openid profile',
           loadUserInfo: false


### PR DESCRIPTION
Currently you cannot change the redirect_uri when using OAuth2 or the old style of openidconnect configuration. As the file picker is to be used as parts of other projects and requires its own oidc-callback.html file to be redirected to I propose to make the redirect_uri configurable. The advantage is that the oidc-callback.html then can reside in any subfolder of the project.

