### PR TITLE
Cancel and select button

### DIFF
--- a/changelog/unreleased/enhancement-cancellation
+++ b/changelog/unreleased/enhancement-cancellation
@@ -1,0 +1,7 @@
+Enhancement: Cancelling the file picker
+
+We added two options for emitting a `cancel` event from the file picker:
+- pressing ESC on the keyboard while the file picker is focussed
+- clicking the new `Cancel` button which appears in the top bar as soon as a `cancelBtnLabel` is provided
+
+https://github.com/owncloud/file-picker/pull/29

--- a/changelog/unreleased/enhancement-select-button
+++ b/changelog/unreleased/enhancement-select-button
@@ -1,0 +1,5 @@
+Enhancement: Select button label
+
+It is now possible to provide a dedicated label overriding the default Select button label.
+
+https://github.com/owncloud/file-picker/pull/29

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,9 @@ Location of the file can be provided via a prop called `configLocation`. This re
 }
 ```
 
+### Pass bearer token
+In case you already have a bearer token and want to skip the whole authorization process inside of the File picker, you can pass it to the component via prop called `bearerToken`.
+
 ## Install File picker package
 To integrate File picker into your own product, you can install it via one of the following commands:
 
@@ -109,6 +112,3 @@ export default: {
 As described in [Getting Started]({{< ref "getting-started.md#components-of-the-file-picker" >}}), File picker comes in two variations. To define which one should be used, you need to pass it to the component via its `variation` property. Valid values are:
 - `resource` - File picker
 - `location` - Location picker
-
-## Pass bearer token
-In case you already have a bearer token and want to skip the whole authorization process inside of the File picker, you can pass it to the component via prop called `bearerToken`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -112,3 +112,16 @@ export default: {
 As described in [Getting Started]({{< ref "getting-started.md#components-of-the-file-picker" >}}), File picker comes in two variations. To define which one should be used, you need to pass it to the component via its `variation` property. Valid values are:
 - `resource` - File picker
 - `location` - Location picker
+
+## Buttons and events
+The wording of buttons can be customized.
+
+### Select button
+The file picker has a button in the top right for emitting an event with the selected location or resource, depending on the configured variation.
+This button has default labels, depending on the chosen variation. However, it is possible to define a different button label by setting
+`select-btn-label="<your select button label>""`. Using the select button will emit an event with the name `selectResources`.
+
+### Cancel button
+Cancellation for the file picker is disabled by default. When a label is provided, the file picker renders a cancel button on the left side of the select button.
+This can be achieved by setting `cancel-btn-label="<your cancel button label>""`. This will also add a keyboard event on the `ESC` key. Using
+the cancel button or the `ESC` key on the keyboard will emit an event with the name `cancel`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -119,9 +119,9 @@ The wording of buttons can be customized.
 ### Select button
 The file picker has a button in the top right for emitting an event with the selected location or resource, depending on the configured variation.
 This button has default labels, depending on the chosen variation. However, it is possible to define a different button label by setting
-`select-btn-label="<your select button label>""`. Using the select button will emit an event with the name `selectResources`.
+`select-btn-label="<your select button label>"`. Using the select button will emit an event with the name `selectResources`.
 
 ### Cancel button
 Cancellation for the file picker is disabled by default. When a label is provided, the file picker renders a cancel button on the left side of the select button.
-This can be achieved by setting `cancel-btn-label="<your cancel button label>""`. This will also add a keyboard event on the `ESC` key. Using
+This can be achieved by setting `cancel-btn-label="<your cancel button label>"`. This will also add a keyboard event on the `ESC` key. Using
 the cancel button or the `ESC` key on the keyboard will emit an event with the name `cancel`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="oc-file-picker" class="uk-height-1-1">
+  <div id="oc-file-picker" class="uk-height-1-1" tabindex="0" @keyup.esc="cancel">
     <div
       v-if="state === 'loading'"
       class="uk-height-1-1 uk-width-1-1 uk-flex uk-flex-middle uk-flex-center oc-border"
@@ -12,7 +12,10 @@
       key="file-picker"
       class="uk-height-1-1"
       :variation="variation"
+      :select-btn-label="selectBtnLabel"
+      :cancel-btn-label="cancelBtnLabel"
       @selectResources="selectResources"
+      @cancel="cancel"
     />
   </div>
 </template>
@@ -67,6 +70,16 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    selectBtnLabel: {
+      type: String,
+      required: false,
+      default: null
+    },
+    cancelBtnLabel: {
+      type: String,
+      required: false,
+      default: null
     }
   },
 
@@ -134,6 +147,14 @@ export default {
 
     selectResources(resources) {
       this.$emit('selectResources', resources)
+    },
+
+    cancel() {
+      if (this.cancelBtnLabel === null) {
+        // don't propagate cancel events if we don't have a cancel button
+        return
+      }
+      this.$emit('cancel')
     }
   }
 }

--- a/src/components/FilePicker.vue
+++ b/src/components/FilePicker.vue
@@ -5,8 +5,11 @@
       :is-select-btn-enabled="isSelectBtnEnabled"
       :is-location-picker="isLocationPicker"
       :are-resources-selected="areResourcesSelected"
+      :select-btn-label="selectBtnLabel"
+      :cancel-btn-label="cancelBtnLabel"
       @openFolder="loadFolder"
       @select="emitSelectedResources"
+      @cancel="emitCancel"
     />
     <div
       v-if="state === 'loading'"
@@ -29,7 +32,7 @@
 </template>
 
 <script>
-import { buildResource } from '../helpers/resources'
+import { buildResource } from '@/helpers/resources'
 import ListResources from './ListResources.vue'
 import ListHeader from './ListHeader.vue'
 
@@ -46,6 +49,16 @@ export default {
       type: String,
       required: true,
       validator: value => value === 'resource' || 'location'
+    },
+    selectBtnLabel: {
+      type: String,
+      required: false,
+      default: null
+    },
+    cancelBtnLabel: {
+      type: String,
+      required: false,
+      default: null
     }
   },
 
@@ -111,6 +124,10 @@ export default {
 
     emitSelectedResources() {
       this.$emit('selectResources', this.selectedResources)
+    },
+
+    emitCancel() {
+      this.$emit('cancel')
     }
   }
 }

--- a/src/components/ListHeader.vue
+++ b/src/components/ListHeader.vue
@@ -4,13 +4,20 @@
     <oc-breadcrumb class="oc-light" :items="breadcrumbsItems" />
     <div>
       <oc-button
+        v-if="cancelBtnLabel"
+        class="file-picker-btn-cancel uk-margin-small-right"
+        @click="cancel"
+      >
+        {{ cancelBtnLabel }}
+      </oc-button>
+      <oc-button
         class="file-picker-btn-select-resources"
         variation="primary"
         :disabled="!isSelectBtnEnabled"
         :uk-tooltip="disabledSelectBtnTooltip"
         @click="select"
       >
-        {{ selectBtnLabel }}
+        {{ submitBtnLabel }}
       </oc-button>
     </div>
   </header>
@@ -31,6 +38,16 @@ export default {
     isSelectBtnEnabled: {
       type: Boolean,
       required: true
+    },
+    selectBtnLabel: {
+      type: String,
+      required: false,
+      default: null
+    },
+    cancelBtnLabel: {
+      type: String,
+      required: false,
+      default: null
     },
     isLocationPicker: {
       type: Boolean,
@@ -83,7 +100,11 @@ export default {
       return 'Please select at least one resource. You can select a resource by clicking on its row or via its checkbox.'
     },
 
-    selectBtnLabel() {
+    submitBtnLabel() {
+      if (this.selectBtnLabel) {
+        return this.selectBtnLabel
+      }
+
       if (this.isLocationPicker) {
         return this.areResourcesSelected ? 'Select folder' : 'Select current folder'
       }
@@ -99,6 +120,10 @@ export default {
 
     select() {
       this.$emit('select')
+    },
+
+    cancel() {
+      this.$emit('cancel')
     }
   }
 }

--- a/tests/helpers/mocks.js
+++ b/tests/helpers/mocks.js
@@ -1,7 +1,7 @@
 import moment from 'moment'
 
 const getCurrentDate = () => {
-  return moment().format('ddd, DD MMM YYYY hh')
+  return moment().format('ddd, DD MMM YYYY HH:mm:ss') + ' GMT'
 }
 
 export const testResources = [
@@ -17,7 +17,7 @@ export const testResources = [
       '{http://owncloud.org/ns}share-types': '',
       '{http://owncloud.org/ns}privatelink': 'http://host.docker.internal:8080/f/144055',
       '{http://owncloud.org/ns}size': '7505867',
-      '{DAV:}getlastmodified': getCurrentDate() + ':00:00 GMT',
+      '{DAV:}getlastmodified': getCurrentDate(),
       '{DAV:}getetag': '"5fc4c975019f9"',
       '{DAV:}resourcetype': [{}]
     },
@@ -35,7 +35,7 @@ export const testResources = [
       '{http://owncloud.org/ns}share-types': '',
       '{http://owncloud.org/ns}privatelink': 'http://host.docker.internal:8080/f/144227',
       '{http://owncloud.org/ns}size': '0',
-      '{DAV:}getlastmodified': getCurrentDate() + ' GMT',
+      '{DAV:}getlastmodified': getCurrentDate(),
       '{DAV:}getetag': '"5fb64a9d08be7"',
       '{DAV:}resourcetype': [{}]
     },
@@ -53,7 +53,7 @@ export const testResources = [
       '{http://owncloud.org/ns}share-types': '',
       '{http://owncloud.org/ns}privatelink': 'http://host.docker.internal:8080/f/144228',
       '{http://owncloud.org/ns}size': '1395095',
-      '{DAV:}getlastmodified': getCurrentDate() + ' GMT',
+      '{DAV:}getlastmodified': getCurrentDate(),
       '{DAV:}getetag': '"5fb64b0c5ba65"',
       '{DAV:}resourcetype': [{}]
     },
@@ -72,7 +72,7 @@ export const testResources = [
       '{http://owncloud.org/ns}privatelink': 'http://host.docker.internal:8080/f/144242',
       '{DAV:}getcontentlength': '6110772',
       '{http://owncloud.org/ns}size': '6110772',
-      '{DAV:}getlastmodified': getCurrentDate() + ' GMT',
+      '{DAV:}getlastmodified': getCurrentDate(),
       '{DAV:}getetag': '"4b585b2818ce17bd711919b56d1bdaf2"',
       '{DAV:}resourcetype': ''
     },

--- a/tests/helpers/mocks.js
+++ b/tests/helpers/mocks.js
@@ -1,7 +1,7 @@
 import moment from 'moment'
 
 const getCurrentDate = () => {
-  return moment().format('ddd, DD MMM YYYY HH:mm:ss') + ' GMT'
+  return moment().toISOString()
 }
 
 export const testResources = [

--- a/tests/unit/__snapshots__/filePicker.spec.js.snap
+++ b/tests/unit/__snapshots__/filePicker.spec.js.snap
@@ -29,7 +29,7 @@ exports[`File picker renders a list of resources 1`] = `
                 </div>
                 <div class="uk-text-meta">
                   0 B - Last modified
-                  in 2 hours
+                  a few seconds ago
                 </div>
               </div>
             </div>
@@ -50,7 +50,7 @@ exports[`File picker renders a list of resources 1`] = `
                 </div>
                 <div class="uk-text-meta">
                   1.3 MB - Last modified
-                  in 2 hours
+                  a few seconds ago
                 </div>
               </div>
             </div>
@@ -69,7 +69,7 @@ exports[`File picker renders a list of resources 1`] = `
                 <div filename="ownCloud Manual.pdf" class="file-row-name uk-text-truncate"><span role="button" class="uk-text-bold oc-cursor-pointer oc-file-name uk-padding-remove-left">ownCloud Manual</span><span class="uk-text-meta oc-file-extension">.pdf</span></div>
                 <div class="uk-text-meta">
                   5.8 MB - Last modified
-                  in 2 hours
+                  a few seconds ago
                 </div>
               </div>
             </div>

--- a/tests/unit/__snapshots__/filePicker.spec.js.snap
+++ b/tests/unit/__snapshots__/filePicker.spec.js.snap
@@ -1,10 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`File picker renders list of resources 1`] = `
+exports[`File picker renders a list of resources 1`] = `
 <div class="uk-height-1-1 uk-flex uk-flex-column uk-overflow-hidden">
   <header class="uk-background-primary uk-padding-small uk-flex uk-flex-middle uk-flex-between">
     <oc-breadcrumb-stub items="[object Object]" class="oc-light"></oc-breadcrumb-stub>
     <div>
+      <!---->
       <oc-button-stub variation="primary" disabled="true" uk-tooltip="Please select at least one resource. You can select a resource by clicking on its row or via its checkbox." class="file-picker-btn-select-resources">
         Select resources
       </oc-button-stub>
@@ -28,7 +29,7 @@ exports[`File picker renders list of resources 1`] = `
                 </div>
                 <div class="uk-text-meta">
                   0 B - Last modified
-                  10 hours ago
+                  in 2 hours
                 </div>
               </div>
             </div>
@@ -49,7 +50,7 @@ exports[`File picker renders list of resources 1`] = `
                 </div>
                 <div class="uk-text-meta">
                   1.3 MB - Last modified
-                  10 hours ago
+                  in 2 hours
                 </div>
               </div>
             </div>
@@ -68,7 +69,7 @@ exports[`File picker renders list of resources 1`] = `
                 <div filename="ownCloud Manual.pdf" class="file-row-name uk-text-truncate"><span role="button" class="uk-text-bold oc-cursor-pointer oc-file-name uk-padding-remove-left">ownCloud Manual</span><span class="uk-text-meta oc-file-extension">.pdf</span></div>
                 <div class="uk-text-meta">
                   5.8 MB - Last modified
-                  10 hours ago
+                  in 2 hours
                 </div>
               </div>
             </div>

--- a/tests/unit/filePicker.spec.js
+++ b/tests/unit/filePicker.spec.js
@@ -14,7 +14,7 @@ localVue.prototype.$client = {
 }
 
 describe('File picker', () => {
-  it('renders list of resources', async () => {
+  it('renders a list of resources', async () => {
     const wrapper = mount(FilePicker, {
       localVue,
       propsData: {
@@ -29,6 +29,20 @@ describe('File picker', () => {
 
     expect(wrapper.findAll('[filename="ownCloud Manual.pdf"]').length).toEqual(1)
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it('renders the select button with the provided label', () => {
+    const wrapper = mount(FilePicker, {
+      localVue,
+      propsData: {
+        variation: 'resource',
+        selectBtnLabel: 'TestLabel'
+      },
+      stubs
+    })
+
+    expect(wrapper.findAll('.file-picker-btn-select-resources').length).toBe(1)
+    expect(wrapper.find('.file-picker-btn-select-resources').text()).toBe('TestLabel')
   })
 
   it('emits selected resources', async () => {
@@ -54,5 +68,49 @@ describe('File picker', () => {
 
     // Need to access nested array
     expect(wrapper.emitted().selectResources[0][0]).toContain('Documents')
+  })
+
+  it('has no cancel button by default', () => {
+    const wrapper = mount(FilePicker, {
+      localVue,
+      propsData: {
+        variation: 'resource'
+      },
+      stubs
+    })
+
+    expect(wrapper.findAll('.file-picker-btn-cancel').length).toBe(0)
+  })
+
+  it('renders a cancel button if a label is provided', () => {
+    const wrapper = mount(FilePicker, {
+      localVue,
+      propsData: {
+        variation: 'resource',
+        cancelBtnLabel: 'Cancel'
+      },
+      stubs
+    })
+
+    expect(wrapper.findAll('.file-picker-btn-cancel').length).toBe(1)
+    expect(wrapper.find('.file-picker-btn-cancel').text()).toBe('Cancel')
+  })
+
+  it('emits a cancel event on button click', async () => {
+    const wrapper = mount(FilePicker, {
+      localVue,
+      propsData: {
+        variation: 'resource',
+        cancelBtnLabel: 'Cancel'
+      },
+      stubs
+    })
+
+    // Emit click event instead of calling `trigger()` due to stubbed component
+    wrapper.find('.file-picker-btn-cancel').vm.$emit('click')
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted().cancel).toBeTruthy()
   })
 })


### PR DESCRIPTION
This PR adds properties for providing labels for the `select` and `cancel` buttons. The `cancel` button is entirely new with this PR.

Todo:
- [x] tests
- [x] changelog
- [x] add keylistener on filepicker div, not on document