### PR TITLE
feat: add initial focus

### DIFF
--- a/changelog/unreleased/enhancement-initial-focus
+++ b/changelog/unreleased/enhancement-initial-focus
@@ -1,0 +1,5 @@
+Enhancement: Add initial focus
+
+We've added an initial focus so that when the File picker is mounted, it immediately becomes focused.
+
+https://github.com/owncloud/file-picker/pull/44

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="oc-file-picker" tabindex="0" @keyup.esc="cancel">
+  <div id="oc-file-picker" ref="filePicker" tabindex="-1" @keyup.esc="cancel">
     <div
       v-if="state === 'loading'"
       class="uk-height-1-1 uk-width-1-1 uk-flex uk-flex-middle uk-flex-center oc-border"
@@ -108,6 +108,10 @@ export default {
     }
 
     this.initAuthentication()
+  },
+
+  mounted() {
+    this.$refs.filePicker.focus()
   },
 
   beforeDestroy() {


### PR DESCRIPTION
We've added an initial focus so that when the File picker is mounted, it immediately becomes focused.