### PR TITLE
feat: use in-memory storage

### DIFF
--- a/changelog/unreleased/change-use-memory-storage
+++ b/changelog/unreleased/change-use-memory-storage
@@ -1,0 +1,7 @@
+Change: Keep user token in the memory storage
+
+We've switched the location to save bearer token from browser session storage to an in-memory based storage.
+Session storage cannot be safely used anymore as modern browsers are starting to block third party iframes from accessing it.
+
+https://github.com/owncloud/file-picker/issues/67
+https://github.com/owncloud/file-picker/pull/74

--- a/changelog/unreleased/change-use-memory-storage
+++ b/changelog/unreleased/change-use-memory-storage
@@ -1,7 +1,0 @@
-Change: Keep user token in the memory storage
-
-We've switched the location to save bearer token from browser session storage to an in-memory based storage.
-Session storage cannot be safely used anymore as modern browsers are starting to block third party iframes from accessing it.
-
-https://github.com/owncloud/file-picker/issues/67
-https://github.com/owncloud/file-picker/pull/74

--- a/changelog/unreleased/enhancement-use-memory-storage
+++ b/changelog/unreleased/enhancement-use-memory-storage
@@ -1,0 +1,6 @@
+Enhancement: Add memory storage option
+
+We've added an option to store the Bearer token in memory storage instead of session storage.
+
+https://github.com/owncloud/file-picker/issues/67
+https://github.com/owncloud/file-picker/pull/74

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,6 +58,13 @@ npm install @ownclouders/file-picker --save
 yarn add @ownclouders/file-picker
 ```
 
+## Select browser storage
+In order to authorize any request to the ownCloud server, we are storing the Bearer token in a browser storage. By default, it is the session storage. As browsers are adding more strict policies when it comes to blocking third party cookies, your users might experience issues with the token not being saved in the storage. For this reason, it is possible to specify a storage name in the config of File picker. To make it possible to run the File picker inside of an iframe, specify `storage: memory`.
+
+{{< hint danger >}}
+If the memory storage is used, it is not persisted in the session. This leads to users having to authorize again after a refresh has happened.
+{{< /hint >}}
+
 ## Integrate in HTML page with vanilla JavaScript
 When including File picker in an HTML page, it is important to include Vue.js as well. In this case, we will import it via [unpkg](https://unpkg.com). Without this, the component won't work. Vue needs to be included also if you're importing the File picker into a web application built with other framework than Vue (e.g. React, Angular).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,6 +65,10 @@ In order to authorize any request to the ownCloud server, we are storing the Bea
 If the memory storage is used, it is not persisted in the session. This leads to users having to authorize again after a refresh has happened.
 {{< /hint >}}
 
+{{< hint info >}}
+Users might still be experiencing issues with the authorization even if memory storage is used. That can happen due to authorization popup needing to trigger a callback in the File picker. To make sure it will work as supposed, be sure to set correct CORS headers.
+{{< /hint >}}
+
 ## Integrate in HTML page with vanilla JavaScript
 When including File picker in an HTML page, it is important to include Vue.js as well. In this case, we will import it via [unpkg](https://unpkg.com). Without this, the component won't work. Vue needs to be included also if you're importing the File picker into a web application built with other framework than Vue (e.g. React, Angular).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,7 +66,7 @@ If the memory storage is used, it is not persisted in the session. This leads to
 {{< /hint >}}
 
 {{< hint info >}}
-Users might still be experiencing issues with the authorization even if memory storage is used. That can happen due to authorization popup needing to trigger a callback in the File picker. To make sure it will work as supposed, be sure to set correct CORS headers.
+Users might still be experiencing issues with the authentication even if the memory storage is used. That can happen due to the authentication popup needing to trigger a callback in the File picker. To make sure it will work as supposed, be sure to set correct CORS headers.
 {{< /hint >}}
 
 ## Integrate in HTML page with vanilla JavaScript

--- a/public/oidc-callback.html
+++ b/public/oidc-callback.html
@@ -9,16 +9,10 @@
 <body>
   <script src="oidc-client.min.js"></script>
   <script>
+    Oidc.Log.logger = console;
+    Oidc.Log.level = Oidc.Log.INFO;
 
-    var mgr = new Oidc.UserManager({userStore: new Oidc.WebStorageStateStore(), loadUserInfo: true, filterProtocolClaims: true});
-    
-    mgr.signinPopupCallback().then(function (user) {
-      console.log(user)
-      window.location.href = '../';
-    }).catch(function (err) {
-      console.log(err);
-    });
-
+    new Oidc.UserManager().signinPopupCallback();
   </script>
 </body>
 


### PR DESCRIPTION
By specifying `storage: memory` in the json config of file picker, we can use the in-memory storage instead of session storage.