### PR TITLE
feat: emit current folder and fix update type

### DIFF
--- a/changelog/unreleased/bugfix-emit-location-as-array
+++ b/changelog/unreleased/bugfix-emit-location-as-array
@@ -1,0 +1,7 @@
+Bugfix: Emit location as an array
+
+When loading new folder in Location picker, we are emitting an "update" with the current route as an argument.
+We've fixed that the argument has type array now so that it is consistent with all other arguments returned in the "update" event.
+
+https://github.com/owncloud/file-picker/issues/71
+https://github.com/owncloud/file-picker/pull/75

--- a/changelog/unreleased/enhancement-folderLoaded-event
+++ b/changelog/unreleased/enhancement-folderLoaded-event
@@ -1,0 +1,7 @@
+Enhancement: Emit current folder in "folderLoaded" event
+
+We've added event called "folderLoaded" that is emitted every time a loading of any folder has ended.
+It is emitting the current folder as an argument.
+
+https://github.com/owncloud/file-picker/issues/71
+https://github.com/owncloud/file-picker/pull/75

--- a/docs/accessing-resources.md
+++ b/docs/accessing-resources.md
@@ -9,7 +9,7 @@ geekdocFilePath: accessing-resources.md
 
 {{< toc >}}
 
-File picker is returning selected resources via event called `selectResources`. To access them, you need to set an event listener where you'll be able to get them as part of the response of the callback function.
+If using File picker as a web component, it is returning selected resources via events called `select` and `update`. To access them, you need to set an event listener where you'll be able to get them as part of the response of the callback function.
 
 ## Access resources
 ```html
@@ -19,7 +19,7 @@ File picker is returning selected resources via event called `selectResources`. 
   const item = document.getElementById('file-picker')
   let resources = []
 
-  item.addEventListener('selectResources', event => {
+  item.addEventListener('select', event => {
     resources = event.detail[0]
   })
 </script>

--- a/docs/component-reference.md
+++ b/docs/component-reference.md
@@ -32,3 +32,4 @@ geekdocFilePath: component-reference.md
 | `update` | Resources array | Emitted when any resource is selected or deselected or if a folder has been loaded in location picker |
 | `select` | Resources array | Emitted when the select button is clicked |
 | `cancel` | Native click event object | Emitted when the cancel button is clicked |
+| `folderLoaded` | Current folder object | Emitted when loading of a folder has ended |

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@
       @update="selectResources"
       @select="emitSelectBtnClick"
       @cancel="cancel"
+      @folderLoaded="onFolderLoaded"
     />
   </div>
 </template>
@@ -216,6 +217,10 @@ export default {
       }
       this.$emit('cancel')
     },
+
+    onFolderLoaded(folder) {
+      this.$emit('folderLoaded', folder)
+    }
   },
 }
 </script>

--- a/src/components/FilePicker.vue
+++ b/src/components/FilePicker.vue
@@ -119,8 +119,10 @@ export default {
           this.currentFolder = resources[0]
 
           if (this.isLocationPicker) {
-            this.$emit('update', this.currentFolder)
+            this.$emit('update', [this.currentFolder])
           }
+
+          this.$emit('folderLoaded', this.currentFolder)
 
           this.state = 'loaded'
         })

--- a/tests/integration/specs/filePicker.spec.js
+++ b/tests/integration/specs/filePicker.spec.js
@@ -64,13 +64,31 @@ describe('Users can select location from within the file picker', () => {
 
     await waitFor(() => expect(getByTestId('list-resources-table')).toBeVisible())
 
-    expect(emitted().update[emitted().update.length - 1][0].id).toEqual('144055')
+    expect(emitted().update[emitted().update.length - 1][0][0].id).toEqual('144055')
 
     await fireEvent.click(getByText('Photos'))
 
     await waitFor(() => expect(getByText('Teotihuacan')).toBeVisible())
 
-    expect(emitted().update[emitted().update.length - 1][0].id).toEqual('144228')
+    expect(emitted().update[emitted().update.length - 1][0][0].id).toEqual('144228')
+  })
+
+  test('Developers can get current loaded folder from "folderLoaded" event after the load is finished', async () => {
+    const { getByTestId, emitted, getByText } = render(FilePicker, {
+      props: {
+        variation: 'location',
+      },
+    })
+
+    await waitFor(() => expect(getByTestId('list-resources-table')).toBeVisible())
+
+    expect(emitted().folderLoaded[0][0].id).toEqual('144055')
+
+    await fireEvent.click(getByText('Photos'))
+
+    await waitFor(() => expect(getByText('Teotihuacan')).toBeVisible())
+
+    expect(emitted().folderLoaded[1][0].id).toEqual('144228')
   })
 })
 


### PR DESCRIPTION
When loading new folder in Location picker, we are emitting an "update" with the current route as an argument. We've fixed that the argument has type array now so that it is consistent with all other arguments returned in the `update` event. We've also added event called `folderLoaded` that is emitted every time a loading of any folder has ended.
It is emitting the current folder as an argument.

Fixes #71