### PR TITLE
fix: non-interactible current folder in breadcrumbs

### DIFF
--- a/changelog/unreleased/bugfix-current-breadcrumb-item
+++ b/changelog/unreleased/bugfix-current-breadcrumb-item
@@ -1,4 +1,4 @@
-Bugfix: Current breadcrumb item is shouldn't be interactable
+Bugfix: Current breadcrumb item shouldn't be interactable
 
 We've fixed the last item in the breadcrumb which is equal to the current folder so that it is not interactable anymore.
 

--- a/changelog/unreleased/bugfix-current-breadcrumb-item
+++ b/changelog/unreleased/bugfix-current-breadcrumb-item
@@ -1,0 +1,6 @@
+Bugfix: Current breadcrumb item is shouldn't be interactable
+
+We've fixed the last item in the breadcrumb which is equal to the current folder so that it is not interactable anymore.
+
+https://github.com/owncloud/file-picker/issues/64
+https://github.com/owncloud/file-picker/pull/76

--- a/src/components/ListHeader.vue
+++ b/src/components/ListHeader.vue
@@ -68,31 +68,25 @@ export default {
 
   computed: {
     breadcrumbsItems() {
-      let breadcrumbs = [
-        {
-          text: this.$gettext('Home'),
-          onClick: () => this.openFolder('/'),
-        },
-      ]
+      const breadcrumbs = []
 
       if (!this.currentFolder) {
         return breadcrumbs
       }
 
-      const pathSplit = this.currentFolder.path ? this.currentFolder.path.split('/') : []
+      const pathSplit = this.currentFolder.path ? this.currentFolder.path.split('/') : ['']
 
-      for (let i = 1; i < pathSplit.length; i++) {
+      for (let i = 0; i < pathSplit.length; i++) {
         let itemPath = encodeURIComponent(path.join.apply(null, pathSplit.slice(0, i + 1)))
-
-        if (i === pathSplit.length - 1) {
-          itemPath = null
-        }
 
         breadcrumbs.push({
           index: i,
-          text: pathSplit.slice(0, i + 1)[i],
-          onClick: () => this.openFolder(itemPath),
+          text: i === 0 ? this.$gettext('Home') : pathSplit.slice(0, i + 1)[i],
         })
+
+        if (pathSplit.length > 1 && i < pathSplit.length - 1) {
+          breadcrumbs[i].onClick = () => this.openFolder(itemPath || '/')
+        }
       }
 
       return breadcrumbs

--- a/tests/unit/listHeader.spec.js
+++ b/tests/unit/listHeader.spec.js
@@ -56,4 +56,15 @@ describe('List header', () => {
 
     expect(wrapper.find('[data-testid="list-header-btn-cancel"]').exists()).toBeFalsy()
   })
+
+  it("doesn't insert last breadcrumb item as interactible element", () => {
+    const wrapper = shallowMount(ListHeader, {
+      propsData: defaultProps,
+      stubs,
+    })
+
+    expect(typeof wrapper.vm.breadcrumbsItems[0].onClick).toEqual('function')
+    expect(typeof wrapper.vm.breadcrumbsItems[1].onClick).toEqual('function')
+    expect(wrapper.vm.breadcrumbsItems[2].onClick).toEqual(undefined)
+  })
 })


### PR DESCRIPTION
We've fixed the last item in the breadcrumb which is equal to the current folder so that it is not interactable anymore.

- fixes #64