### PR TITLE
feat: handle focus after folder load

### DIFF
--- a/changelog/unreleased/enhancement-focus-mngmt
+++ b/changelog/unreleased/enhancement-focus-mngmt
@@ -1,6 +1,6 @@
 Enhancement: focus last breadcrumb item
 
-We've added focus management so that the last breadcrumb item will be focus after a folder has been loaded.
+We've added focus management so that the last breadcrumb item will be focused after a folder has been loaded.
 By default, this focus management is disabled on the first load when opening the file picker.
 To enable it also during the first load, set prop `isInitialFocusEnabled` to `true`.
 

--- a/changelog/unreleased/enhancement-focus-mngmt
+++ b/changelog/unreleased/enhancement-focus-mngmt
@@ -1,0 +1,7 @@
+Enhancement: focus last breadcrumb item
+
+We've added focus management so that the last breadcrumb item will be focus after a folder has been loaded.
+By default, this focus management is disabled on the first load when opening the file picker.
+To enable it also during the first load, set prop `isInitialFocusEnabled` to `true`.
+
+https://github.com/owncloud/file-picker/pull/79

--- a/docs/component-reference.md
+++ b/docs/component-reference.md
@@ -25,6 +25,7 @@ geekdocFilePath: component-reference.md
 | `cancelBtnLabel` | `String` | `nulll` | Displays the cancel button and uses the given value as a label |
 | `isOdsProvided` | `Boolean` | `false` | Asserts whether the ownCloud Design System has been already initialised in the consuming app |
 | `locale` | `String` | `null` | Sets the language in which the File Picker should be displayed. If omitted, the browser language will be used |
+| `isInitialFocusEnabled` | `Boolean` | `false` | Enables focusing last item of breadcrumbs after the first folder has been loaded |
 
 ## Events
 | Event | Arguments | Description |

--- a/docs/focus-management.md
+++ b/docs/focus-management.md
@@ -8,15 +8,18 @@ geekdocFilePath: focus-management.md
 
 {{< toc >}}
 
-File Picker doesn't come with a focus management. Any element needs to be focused through a code in the consuming app.
+File Picker comes only with partial focus management. If you want to focus an element, it needs to be achieved through a code in the consuming app.
 
 ## Focusing content of File Picker
 If you're including File Picker as a web component, managing focus is slightly different from focusing content of any other component in the DOM tree. Since web component are living in shadow root, we need to send the focus into it. To focus e.g. a checkbox within the File Picker, you can use the following code.
 
 ```js
-document.querySelector('#file-picker').shadowRoot.querySelector('#oc-checkbox-3').focus()
+document.querySelector('#file-picker').shadowRoot.querySelector('.oc-breadcrumb-list-item span[aria-current="page"]').focus()
 ```
 
 {{< hint info >}}
 The `#file-picker` selector is coming from the consuming app, not from File Picker.
 {{< /hint >}}
+
+## Initial folder load focus
+After opening a folder, we are focusing the last item of breadcrumbs. This is not the case when loading the first folder. Any following navigation into the first folder will focus the item. To enable focus on the first load as well, you need to set `isInitialFocusEnabled` prop to `true`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@
       :select-btn-label="selectBtnLabel"
       :is-select-btn-displayed="isSelectBtnDisplayed"
       :cancel-btn-label="cancelBtnLabel"
+      :is-initial-focus-enabled="isInitialFocusEnabled"
       @update="selectResources"
       @select="emitSelectBtnClick"
       @cancel="cancel"
@@ -123,6 +124,11 @@ export default {
       required: false,
       default: null,
     },
+    isInitialFocusEnabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   data: () => ({
@@ -220,7 +226,7 @@ export default {
 
     onFolderLoaded(folder) {
       this.$emit('folderLoaded', folder)
-    }
+    },
   },
 }
 </script>

--- a/src/components/FilePicker.vue
+++ b/src/components/FilePicker.vue
@@ -37,6 +37,8 @@ import { buildResource } from '@/helpers/resources'
 import ListResources from './ListResources.vue'
 import ListHeader from './ListHeader.vue'
 
+import MixinAccessibility from '@/mixins/accessibility'
+
 export default {
   name: 'FilePicker',
 
@@ -44,6 +46,8 @@ export default {
     ListHeader,
     ListResources,
   },
+
+  mixins: [MixinAccessibility],
 
   props: {
     variation: {
@@ -66,6 +70,11 @@ export default {
       required: false,
       default: true,
     },
+    isInitialFocusEnabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   data: () => ({
@@ -87,6 +96,7 @@ export default {
       '{DAV:}getetag',
       '{DAV:}resourcetype',
     ],
+    isInitial: true,
   }),
 
   computed: {
@@ -125,6 +135,14 @@ export default {
           this.$emit('folderLoaded', this.currentFolder)
 
           this.state = 'loaded'
+
+          if ((this.isInitial && this.isInitialFocusEnabled) || !this.isInitial) {
+            this.$nextTick(() =>
+              this.$_accessibility_focusAndAnnounceBreadcrumb(this.resources.length)
+            )
+          }
+
+          this.isInitial = false
         })
         .catch((error) => {
           console.error(error)

--- a/src/components/ListHeader.vue
+++ b/src/components/ListHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="file-picker-header uk-padding-small uk-flex uk-flex-middle uk-flex-between">
-    <oc-breadcrumb class="oc-light" :items="breadcrumbsItems" />
+    <oc-breadcrumb class="oc-light" :items="breadcrumbsItems" data-testid="breadcrumbs" />
     <div v-if="cancelBtnLabel || isSelectBtnDisplayed">
       <oc-button
         v-if="cancelBtnLabel"

--- a/src/mixins/accessibility.js
+++ b/src/mixins/accessibility.js
@@ -1,0 +1,30 @@
+export default {
+  methods: {
+    $_accessibility_focusAndAnnounceBreadcrumb(itemsCount) {
+      const activeBreadcrumb = document.querySelector(
+        '.oc-breadcrumb-list-item span[aria-current="page"]'
+      )
+
+      if (!activeBreadcrumb) {
+        return
+      }
+
+      const translated = this.$ngettext(
+        'This folder contains 1 item.',
+        'This folder contains %{ itemsCount } items.',
+        itemsCount
+      )
+      const announcement =
+        itemsCount > 0
+          ? this.$gettextInterpolate(translated, { itemsCount })
+          : this.$gettext('This folder has no content.')
+      const invisibleHint = document.createElement('p')
+
+      invisibleHint.className = 'oc-invisible-sr oc-breadcrumb-sr'
+      invisibleHint.innerHTML = announcement
+
+      activeBreadcrumb.append(invisibleHint)
+      activeBreadcrumb.focus()
+    },
+  },
+}

--- a/tests/integration/config/jest.init.js
+++ b/tests/integration/config/jest.init.js
@@ -16,6 +16,9 @@ config.mocks = {
   },
   $gettext: (str) => str,
   $gettextInterpolate: (str) => str,
+  $ngettext: (arg) => {
+    return arg[2].length > 1 ? arg[1] : arg[0]
+  },
   $language: {
     current: 'en_US',
   },

--- a/tests/integration/specs/filePicker.spec.js
+++ b/tests/integration/specs/filePicker.spec.js
@@ -162,4 +162,19 @@ describe('Users can select resources from within the file picker', () => {
 
     expect(emitted().update[0][0].length).toBe(1)
   })
+
+  test('Last breadcrumb item is focused after folder has been loaded', async () => {
+    const { getByTestId, getByText } = render(FilePicker, {
+      props: {
+        variation: 'resource',
+      },
+    })
+
+    await waitFor(() => expect(getByTestId('list-resources-table')).toBeVisible())
+    await fireEvent.click(getByText('Photos'))
+
+    expect(document.querySelector('.oc-breadcrumb-list-item span[aria-current="page"]')).toBe(
+      document.activeElement
+    )
+  })
 })

--- a/tests/unit/filePicker.spec.js
+++ b/tests/unit/filePicker.spec.js
@@ -115,4 +115,41 @@ describe('File picker', () => {
       expect(wrapper.emitted().folderLoaded[0][0].id).toEqual('144055')
     })
   })
+
+  describe('has focus management', () => {
+    describe('initial folder load', () => {
+      it('does not focus last breadcrumb item if initial focus is disabled', async () => {
+        const wrapper = shallowMount(FilePicker, {
+          localVue,
+          propsData: {
+            variation: 'resource',
+          },
+          stubs,
+        })
+
+        wrapper.vm.$_accessibility_focusAndAnnounceBreadcrumb = jest.fn()
+
+        await waitTillItemsLoaded(wrapper)
+
+        expect(wrapper.vm.$_accessibility_focusAndAnnounceBreadcrumb).not.toHaveBeenCalled()
+      })
+
+      it('focuses last breadcrumb item if initial focus is disabled', async () => {
+        const wrapper = shallowMount(FilePicker, {
+          localVue,
+          propsData: {
+            variation: 'resource',
+            isInitialFocusEnabled: true,
+          },
+          stubs,
+        })
+
+        wrapper.vm.$_accessibility_focusAndAnnounceBreadcrumb = jest.fn()
+
+        await waitTillItemsLoaded(wrapper)
+
+        expect(wrapper.vm.$_accessibility_focusAndAnnounceBreadcrumb).toHaveBeenCalled()
+      })
+    })
+  })
 })


### PR DESCRIPTION
We've added focus management so that the last breadcrumb item will be focus after a folder has been loaded.
By default, this focus management is disabled on the first load when opening the file picker.
To enable it also during the first load, set prop `isInitialFocusEnabled` to `true`.