### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/helpers/resources.js
+++ b/src/helpers/resources.js
@@ -6,7 +6,7 @@ function _extName(fileName) {
   let ext = ''
   const ex = fileName.match(/\.[0-9a-z]+$/i)
   if (ex) {
-    ext = ex[0].substr(1)
+    ext = ex[0].slice(1)
   }
   return ext
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.