### PR TITLE
chore: use https and enable docker host

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,10 @@ module.exports = {
   configureWebpack: {
     resolve: {
       symlinks: false
+    },
+    devServer: {
+      allowedHosts: ['localhost', 'host.docker.internal'],
+      https: true
     }
   },
   css: {


### PR DESCRIPTION
## Motivation
Enable local development using `https://host.docker.internal:8080`