### PR TITLE
Emit access token

### DIFF
--- a/changelog/unreleased/enhancement-token-event
+++ b/changelog/unreleased/enhancement-token-event
@@ -1,0 +1,5 @@
+Enhancement: Token event
+
+We're emitting a `token` event with the current access token whenever the access token gets updated internally.
+
+https://github.com/owncloud/file-picker/pull/205

--- a/docs/component-reference.md
+++ b/docs/component-reference.md
@@ -34,3 +34,4 @@ geekdocFilePath: component-reference.md
 | `select` | Resources array | Emitted when the select button is clicked |
 | `cancel` | Native click event object | Emitted when the cancel button is clicked |
 | `folderLoaded` | Current folder object | Emitted when loading of a folder has ended |
+| `token` | Current access token | Emitted when the access token gets set after authentication or renewal |

--- a/src/App.vue
+++ b/src/App.vue
@@ -139,7 +139,7 @@ export default {
     }
   },
 
-  emits: ['update', 'select', 'cancel', 'folderLoaded'],
+  emits: ['update', 'select', 'cancel', 'folderLoaded', 'token'],
 
   setup(props, { emit }) {
     let authInstance = null
@@ -213,18 +213,22 @@ export default {
         user.value = login
 
         state.value = 'authorized'
+
+        emit('token', token)
       } catch (error) {
         console.error(error)
       }
     }
 
     const updateBearerToken = async () => {
-      let token = await authInstance.getToken()
-      token = token.startsWith('Bearer') ? token : `Bearer ${token}`
+      const token = await authInstance.getToken()
+      const auth = token.startsWith('Bearer') ? token : `Bearer ${token}`
 
-      axiosInstance.defaults.headers.common.Authorization = token
+      axiosInstance.defaults.headers.common.Authorization = auth
 
-      sdk.value.helpers.setAuthorization(token)
+      sdk.value.helpers.setAuthorization(auth)
+
+      emit('token', token)
     }
 
     const checkUserAuthentication = async () => {

--- a/src/components/FilePicker.vue
+++ b/src/components/FilePicker.vue
@@ -160,8 +160,6 @@ export default defineComponent({
       try {
         const { resource, children } = await webdav.value.listFiles(currentSpace, { path })
 
-        console.log(path, currentSpace.driveType)
-
         currentFolder.value =
           resource.path === '/' && currentSpace.driveType === 'personal'
             ? { ...resource, name: proxy?.$gettext('Personal') }


### PR DESCRIPTION
Since the `file-picker` handles authentication the embedding party should be able to use the access token for further ownCloud API calls (e.g. TUS upload after target folder selection).

A more advanced option would be to externalize the authentication and hand over an access token to the file-picker and also use it for the other API calls. For the sake of dev simplicity the new event described above is a valid approach as well.