### PR TITLE
docs: create example of upload into selected location

### DIFF
--- a/docs/accessing-resources.md
+++ b/docs/accessing-resources.md
@@ -24,3 +24,58 @@ If using File picker as a web component, it is returning selected resources via 
   })
 </script>
 ```
+
+## Perform actions with selected resources
+Below is an example code demonstrating how to upload files to the selected location using the File picker, leveraging the [tus-js-client](https://github.com/tus/tus-js-client) library.
+
+```html
+<file-picker id="file-picker" variation="resource"></file-picker>
+
+<script>
+  const filePicker = document.querySelector('#file-picker')
+  const baseURL = 'https://<your-owncloud-server-domain>/remote.php/dav'
+
+  // A mocked file to upload
+  const file = new File(['Hello world!'], 'my-upload-file.md', { type: 'text/markdown' })
+
+  // This will be assigned a value once the token inside the File picker is set
+  let accessToken = ''
+
+  filePicker.addEventListener('select', (event) => {
+    // Select the resource from the event payloads
+    const resource = event.detail[0][0]
+
+    // Create a new tus upload
+    const upload = new tus.Upload(file, {
+      endpoint: baseURL + resource.webDavPath,
+      retryDelays: [0, 3000, 5000, 10000, 20000],
+      metadata: {
+        filename: file.name,
+        filetype: file.type,
+      },
+      headers: {
+        Authorization: accessToken
+      },
+      onError: function (error) {
+        console.log('Failed because: ' + error)
+      },
+      onProgress: function (bytesUploaded, bytesTotal) {
+        const percentage = ((bytesUploaded / bytesTotal) * 100).toFixed(2)
+
+        console.log(bytesUploaded, bytesTotal, percentage + '%')
+      },
+      onSuccess: function () {
+        console.log('File %s successfully uploaded into %s', upload.file.name, upload.url)
+      },
+    })
+
+    // Start the upload
+    upload.start()
+  })
+
+  // Setup a listener that will get the access token necessary to upload the file
+  filePicker.addEventListener('token', (event) => {
+    accessToken = 'Bearer ' + event.detail[0]
+  })
+</script>
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,10 @@ geekdocFilePath: getting-started.md
 
 ownCloud File picker is a web component which can be integrated into existing web applications. It connects to an ownCloud server and enables a user to select resources which are then provided in a response of a fired event. Visit [installation]({{< ref "installation.md" >}}) to see how to integrate the File picker into your product.
 
+{{< hint info >}}
+Please be aware that the File picker provides you with an object representation of the resource and not the actual content itself. In order to perform any actions with the resource, you must utilize the APIs within your own application that integrates the File picker. To see an example of how to upload a file to the location chosen through the File picker, please refer to the following documentation: [Perform actions with selected resources]({{< ref "accessing-resources.md#perform-actions-with-selected-resources" >}}).
+{{< /hint >}}
+
 ## Components of the File picker
 The file picker can be used in two different variations: File picker and location picker.
 


### PR DESCRIPTION
## Summary

Right from the start make it known that the File picker returns only the resource representation instead of the actual file and add an example of how to upload a file with TUS into the selected location.