### PR TITLE
Fix auth renewal

### DIFF
--- a/changelog/unreleased/bugfix-clear-state-when-unauthorized
+++ b/changelog/unreleased/bugfix-clear-state-when-unauthorized
@@ -1,0 +1,8 @@
+Bugfix: Clear state when unauthorized
+
+The filepicker now reacts to `401` responses by resetting the internal authentication state to `unauthorized`,
+forcing the user to log in again.
+This situation can happen when an access token that's not expired, yet, was invalidated server side (e.g. through
+a backchannel logout or session inactivity) and would previously lead to a broken application state.
+
+https://github.com/owncloud/file-picker/pull/211

--- a/changelog/unreleased/bugfix-token-renewal-hook
+++ b/changelog/unreleased/bugfix-token-renewal-hook
@@ -1,0 +1,7 @@
+Bugfix: Reduce requests on token renewal
+
+We've fixed a bug that caused always re-fetching the logged in user and the server capabilities on token renewal
+under certain circumstances. Now the logged in user and the server capabilities are only fetched once after
+successful authentication.
+
+https://github.com/owncloud/file-picker/pull/211

--- a/src/components/FilePicker.vue
+++ b/src/components/FilePicker.vue
@@ -101,7 +101,7 @@ export default defineComponent({
     }
   },
 
-  emits: ['select', 'cancel', 'update', 'folderLoaded'],
+  emits: ['authError', 'cancel', 'folderLoaded', 'select', 'update'],
 
   setup(props, { emit }) {
     let currentSpace = null
@@ -181,6 +181,9 @@ export default defineComponent({
         isInitial = false
       } catch (error) {
         console.error(error)
+        if (error?.response?.status === 401) {
+          emit('authError')
+        }
 
         state.value = 'failed'
       }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -89,12 +89,12 @@ export function initVueAuthenticate(config) {
     })
 
     mgr.events.addSilentRenewError(() => {
-      mgr.clearStaleState()
+      return mgr.clearStaleState()
     })
 
     return {
-      authenticate() {
-        mgr.clearStaleState()
+      async authenticate() {
+        await mgr.clearStaleState()
         return mgr.signinPopup()
       },
 


### PR DESCRIPTION
Fixes two things:

1. adds 401 error handling -> user will be presented with the authenticate button again. Trying to authenticate and then replay the previously failed requests is unfortunately a bigger task - won't happen in this PR (and also not planned effort short term). Did this by adding a) a response interceptor on the axios instance (used for graph API) and b) auth error handling in the catch block of the `loadFolder` method (webdav).
2. the filepicker initialization had a bug which made sense to solve here: if the user was initially authenticated the userLoaded event would always call `updateBearerToken`. If the user was initially unauthenticated the userLoaded event would always call `initApp` (which does a lot of things that are not needed on subsequent token renewals). Corrected the userLoaded event handler to call `initApp` if not in authorized state and then on subsequent token renewals call the `updateBearerToken` method instead.