### PR TITLE
fix: use token prop when set

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -213,7 +213,7 @@ export default {
 
     const initApp = async () => {
       try {
-        const token = await authInstance.getToken()
+        const token = props.bearerToken || (await authInstance.getToken())
         axiosInstance = createAxiosInstance(token)
         const _client = webClient(config.value.server, axiosInstance)
         // const { data: userData } = await _client.graph.users.getMe()


### PR DESCRIPTION
## Summary
When the `bearerToken` prop is set, the token needs to be used instead of trying to get it from the auth instance which of course fails.