### PR TITLE
feat: rename select action label in resource picker

### DIFF
--- a/src/components/ListHeader.vue
+++ b/src/components/ListHeader.vue
@@ -117,7 +117,7 @@ export default defineComponent({
           : proxy?.$gettext('Select current folder')
       }
 
-      return proxy?.$gettext('Select resources')
+      return proxy?.$gettext('Choose')
     })
 
     const emitGoBack = () => {


### PR DESCRIPTION
## Summary

Use label "Choose" instead of "Select resources".

## Related issues

- refs https://github.com/owncloud/file-picker/issues/194