### PR TITLE
feat: bring back shadowRoot

### DIFF
--- a/examples/oc10/index.html
+++ b/examples/oc10/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
     <title>File Picker dev demo</title>
-    <link rel="stylesheet" href="/style.css" />
     <script src="https://unpkg.com/vue@2.7.14/dist/vue.min.js"></script>
     <script src="/file-picker.iife.js"></script>
   </head>

--- a/examples/ocis/index.html
+++ b/examples/ocis/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
     <title>File Picker dev demo</title>
-    <link rel="stylesheet" href="/style.css" />
     <script src="https://unpkg.com/vue@2.7.14/dist/vue.min.js"></script>
     <script src="/file-picker.iife.js"></script>
   </head>

--- a/patches/@vue__web-component-wrapper@1.3.0.patch
+++ b/patches/@vue__web-component-wrapper@1.3.0.patch
@@ -1,26 +1,41 @@
 diff --git a/dist/vue-wc-wrapper.js b/dist/vue-wc-wrapper.js
-index 721bf1f13b0deca95e11d8b6803ccedda0a77cfc..71698d43bb0277214f7f30c1a3c58fa7aeb99cef 100644
+index 721bf1f13b0deca95e11d8b6803ccedda0a77cfc..87a7f33b2ab70b68a9929e092673c0a14437ba5a 100644
 --- a/dist/vue-wc-wrapper.js
 +++ b/dist/vue-wc-wrapper.js
-@@ -167,12 +167,10 @@ function wrap (Vue, Component) {
-   class CustomElement extends HTMLElement {
-     constructor () {
-       const self = super();
--      self.attachShadow({ mode: 'open' });
+@@ -95,7 +95,7 @@ function getAttributes (node) {
+   return res
+ }
  
+-function wrap (Vue, Component) {
++function wrap (Vue, Component, styles) {
+   const isAsync = typeof Component === 'function' && !Component.cid;
+   let isInitialized = false;
+   let hyphenatedPropsList;
+@@ -169,6 +169,13 @@ function wrap (Vue, Component) {
+       const self = super();
+       self.attachShadow({ mode: 'open' });
+ 
++      if (styles) {
++        const style = document.createElement("style");
++        style.textContent = styles;
++
++        self.shadowRoot.appendChild(style);
++      }
++
        const wrapper = self._wrapper = new Vue({
          name: 'shadow-root',
          customElement: self,
--        shadowRoot: self.shadowRoot,
-         data () {
-           return {
-             props: {},
-@@ -246,7 +244,7 @@ function wrap (Vue, Component) {
-           this.childNodes
-         ));
-         wrapper.$mount();
--        this.shadowRoot.appendChild(wrapper.$el);
-+        this.appendChild(wrapper.$el);
-       } else {
-         callHooks(this.vueComponent, 'activated');
-       }
+diff --git a/types/index.d.ts b/types/index.d.ts
+index 8b67b7b2d18a46cd8bbc99b41029e8e103f3b80d..d2c44980eaff6cfbc3605dd9511cf3e0443a7275 100644
+--- a/types/index.d.ts
++++ b/types/index.d.ts
+@@ -2,7 +2,8 @@ import _Vue, { Component, AsyncComponent } from 'vue'
+ 
+ declare function wrap(
+   Vue: typeof _Vue,
+-  Component: Component | AsyncComponent
++  Component: Component | AsyncComponent,
++  styles: string
+ ): HTMLElement
+ 
+ export default wrap

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,12 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   '@vue/web-component-wrapper@1.3.0':
-    hash: csvc6t6c3ulreayfl2jme6puzu
+    hash: erqkam5owipsdictyyzedrkumq
     path: patches/@vue__web-component-wrapper@1.3.0.patch
 
 dependencies:
@@ -11,7 +15,7 @@ dependencies:
     version: 0.0.1(axios@0.27.2)(lodash-es@4.17.21)
   '@vue/web-component-wrapper':
     specifier: ^1.3.0
-    version: 1.3.0(patch_hash=csvc6t6c3ulreayfl2jme6puzu)
+    version: 1.3.0(patch_hash=erqkam5owipsdictyyzedrkumq)
   axios:
     specifier: ^0.27.2
     version: 0.27.2
@@ -2666,7 +2670,7 @@ packages:
       - whiskers
     dev: true
 
-  /@vue/web-component-wrapper@1.3.0(patch_hash=csvc6t6c3ulreayfl2jme6puzu):
+  /@vue/web-component-wrapper@1.3.0(patch_hash=erqkam5owipsdictyyzedrkumq):
     resolution: {integrity: sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==}
     dev: false
     patched: true

--- a/src/App.vue
+++ b/src/App.vue
@@ -353,13 +353,3 @@ export default {
   }
 }
 </script>
-
-<style>
-/* Import oC CI font and design system styles */
-@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap');
-@import '../node_modules/owncloud-design-system/dist/system/system.css';
-
-* {
-  font-family: 'Source Sans Pro', sans-serif;
-}
-</style>

--- a/src/components/ListHeader.vue
+++ b/src/components/ListHeader.vue
@@ -4,7 +4,7 @@
       <button
         v-if="currentFolder !== null"
         data-testid="btn-return"
-        class="btn-return"
+        class="oc-file-picker-btn-return"
         :aria-label="$gettext('Go back')"
         @click="emitGoBack"
       >
@@ -136,17 +136,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style lang="scss" scoped>
-.btn-return {
-  align-items: center;
-  background: transparent;
-  border: none;
-  display: flex;
-  padding: 0;
-
-  &:hover {
-    cursor: pointer;
-  }
-}
-</style>

--- a/src/components/ListResources.vue
+++ b/src/components/ListResources.vue
@@ -20,7 +20,7 @@
         />
         <button
           v-else-if="isLocationPicker && resource.type === 'folder'"
-          class="file-picker-btn-sr-select"
+          class="oc-file-picker-file-picker-btn-sr-select"
           tabindex="0"
           @click="() => selectLocation(resource)"
           v-text="selectLabel(resource.name)"
@@ -130,7 +130,7 @@ export default defineComponent({
       }
 
       isRowDisabled(resource)
-        ? classes.push('files-list-row-disabled')
+        ? classes.push('oc-file-picker-files-list-row-disabled')
         : classes.push('oc-cursor-pointer')
 
       return classes
@@ -158,26 +158,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style lang="scss">
-.files-list-row-disabled {
-  opacity: 0.3;
-  pointer-events: none;
-}
-
-.file-picker-btn-sr-select {
-  position: absolute;
-  z-index: -1;
-  top: var(--oc-space-xsmall);
-  left: var(--oc-space-xsmall);
-  opacity: 0;
-  white-space: nowrap;
-  pointer-events: none;
-
-  &:focus {
-    opacity: 1;
-    z-index: 1;
-    pointer-events: auto;
-  }
-}
-</style>

--- a/src/components/SpacesList.vue
+++ b/src/components/SpacesList.vue
@@ -1,19 +1,25 @@
 <template>
   <oc-list>
     <li class="oc-px-m oc-py-s">
-      <button class="btn-space" @click="() => openSpace('personal', $gettext('Personal'))">
+      <button
+        class="oc-file-picker-btn-space"
+        @click="() => openSpace('personal', $gettext('Personal'))"
+      >
         <oc-icon name="resource-type-folder" size="large" />
         <span v-text="$gettext('Personal')" />
       </button>
     </li>
     <li class="oc-border-t oc-p-m">
-      <button class="btn-space" @click="() => openSpace('shares', $gettext('Shares'))">
+      <button
+        class="oc-file-picker-btn-space"
+        @click="() => openSpace('shares', $gettext('Shares'))"
+      >
         <oc-icon name="share-forward" size="large" />
         <span v-text="$gettext('Shares')" />
       </button>
     </li>
     <li v-for="space in spaces" :key="space.id" class="oc-border-t oc-p-m">
-      <button class="btn-space" @click="() => openSpace(space.id, space.name)">
+      <button class="oc-file-picker-btn-space" @click="() => openSpace(space.id, space.name)">
         <oc-icon name="layout-grid" size="large" />
         <span v-text="space.name" />
       </button>
@@ -43,19 +49,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style scoped lang="scss">
-.btn-space {
-  align-items: center;
-  background: transparent;
-  border: none;
-  display: flex;
-  gap: 0.5rem;
-  padding: 0;
-
-  &:hover {
-    cursor: pointer;
-    text-decoration: underline;
-  }
-}
-</style>

--- a/src/composables/useA11y.ts
+++ b/src/composables/useA11y.ts
@@ -4,7 +4,7 @@ const useA11y = () => {
   const { proxy } = getCurrentInstance() || {}
 
   const focusAndAnnounceBreadcrumb = (itemsCount) => {
-    const activeBreadcrumb: HTMLButtonElement = document.querySelector('.btn-return')
+    const activeBreadcrumb: HTMLButtonElement = document.querySelector('.oc-file-picker-btn-return')
 
     if (!activeBreadcrumb) {
       return

--- a/src/main.lib.ts
+++ b/src/main.lib.ts
@@ -1,3 +1,4 @@
 import FilePicker from './App.vue'
+import './style.css'
 
 export default FilePicker

--- a/src/main.wc.ts
+++ b/src/main.wc.ts
@@ -3,6 +3,7 @@ import wrap from '@vue/web-component-wrapper'
 import { Buffer } from 'buffer'
 import EventEmitter from 'events'
 import process from 'process'
+import styles from './style.css'
 
 import App from './App.vue'
 
@@ -13,7 +14,7 @@ window.process = process
 
 Vue.config.productionTip = false
 
-const FilePicker = wrap(Vue, App)
+const FilePicker = wrap(Vue, App, styles)
 
 // @ts-expect-error mismatch in type comes from the wrapper library
 customElements.define('file-picker', FilePicker)

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap');
+@import '../node_modules/owncloud-design-system/dist/system/system.css';
+
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
@@ -12,6 +14,10 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+}
+
+* {
+  font-family: 'Source Sans Pro', sans-serif;
 }
 
 a {
@@ -64,6 +70,53 @@ button:focus-visible {
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
+}
+
+.oc-file-picker-btn-return {
+  align-items: center;
+  background: transparent;
+  border: none;
+  display: flex;
+  padding: 0;
+}
+
+.oc-file-picker-btn-return:hover {
+  cursor: pointer;
+}
+
+.oc-file-picker-files-list-row-disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.oc-file-picker-file-picker-btn-sr-select {
+  position: absolute;
+  z-index: -1;
+  top: var(--oc-space-xsmall);
+  left: var(--oc-space-xsmall);
+  opacity: 0;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.oc-file-picker-file-picker-btn-sr-select:focus {
+  opacity: 1;
+  z-index: 1;
+  pointer-events: auto;
+}
+
+.oc-file-picker-btn-space {
+  align-items: center;
+  background: transparent;
+  border: none;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0;
+}
+
+.oc-file-picker-btn-space:hover {
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap');
 @import '../node_modules/owncloud-design-system/dist/system/system.css';
 
 :root {
@@ -17,7 +16,7 @@
 }
 
 * {
-  font-family: 'Source Sans Pro', sans-serif;
+  font-family: var(--oc-font-family);
 }
 
 a {

--- a/tests/integration/specs/filePicker.spec.js
+++ b/tests/integration/specs/filePicker.spec.js
@@ -55,7 +55,7 @@ describe('Users can select location from within the file picker', () => {
     expect(await screen.findByText('Invoices')).toBeVisible()
     expect(screen.getByText('readme')).toBeVisible()
     expect(screen.getByTestId(SELECTORS.listRow(resources['/Documents'][2].id))).toHaveClass(
-      'files-list-row-disabled'
+      'oc-file-picker-files-list-row-disabled'
     )
 
     await fireEvent.click(screen.getByTestId(SELECTORS.listRow(resources['/Documents'][1].id)))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,10 @@ export default defineConfig(({ mode }) => {
           {
             src: path.resolve(__dirname, './node_modules/owncloud-design-system/dist/system/icons'),
             dest: path.resolve(__dirname, mode === 'library' ? './dist/lib/' : './dist/wc/')
+          },
+          {
+            src: path.resolve(__dirname, './node_modules/owncloud-design-system/dist/system/fonts'),
+            dest: path.resolve(__dirname, mode === 'library' ? './dist/lib/' : './dist/wc/')
           }
         ]
       })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,7 +56,6 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       outDir: mode === 'library' ? './dist/lib' : './dist/wc',
-      cssCodeSplit: false,
       lib: mode === 'library' ? lib : wc,
       emptyOutDir: false,
       minify: false,


### PR DESCRIPTION
## Summary

Since some of the styles used in the File picker can have an effect on the parent document, it is needed to handle the styles inside of shadowRoot and have them isolated.

One challenge though - vite does not inject styles into the built bundle when library mode is used in the config (open issue here https://github.com/vitejs/vite/issues/1579). This of course brings the problem of including the style inside the shadowRoot. Some plugins exists that can still handle the injection but unfortunately does not work with custom elements as it anyway tries to add the styles into the document instead of shadowRoot. This forces us to append the styles ourselves into the shadowRoot when the custom element is being constructed.

This change does not affect the lib build as the style.css file is still there and can be imported manually in a scoped context.

Theming will be handled via CSS custom properties.